### PR TITLE
Checkboxes need empty strings to be formatted as false.

### DIFF
--- a/lib/formatting/formatters.js
+++ b/lib/formatting/formatters.js
@@ -6,7 +6,7 @@ var formatters = {
 
     boolean: function boolean(value) {
         if (value === true || value === 'true') { return true; }
-        else if (value === false || value === 'false') { return false; }
+        else if (value === false || value === 'false' || value === '') { return false; }
         else { return undefined; }
     },
 

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -71,7 +71,6 @@ function validator(fields) {
                     return err || applyValidator(validator, value, key);
                 }, null);
             } else {
-                values[key] = '';
                 debug('Skipping validation for field %s', key);
             }
         }

--- a/test/spec/spec.formatters.js
+++ b/test/spec/spec.formatters.js
@@ -1,0 +1,45 @@
+var Formatters = require('../../').formatters;
+var _ = require('underscore');
+
+function testName (input) {
+    if (_.isArray(input)) {
+        return testName(input[0]) + ' with args: ' + input.slice(1);
+    } else {
+        return typeof input + ' ' + input;
+    }
+}
+
+describe('Formatters', function () {
+
+    describe('boolean', function () {
+
+        describe('formats to false', function () {
+            var inputs = [
+                false,
+                'false',
+                ''
+            ];
+
+            _.each(inputs, function (i) {
+                it(testName(i), function () {
+                    Formatters.boolean(i).should.not.be.ok;
+                });
+            });
+        });
+
+        describe('formats to true', function () {
+            var inputs = [
+                true,
+                'true'
+            ];
+
+            _.each(inputs, function (i) {
+                it(testName(i), function () {
+                    Formatters.boolean(i).should.be.ok;
+                });
+            });
+        });
+
+    });
+
+});


### PR DESCRIPTION
Checkboxes need empty strings to be formatted as false.

Additionally, why were we wiping out values that had their validation skipped due to a dependency?