### PR TITLE
Unset saved errors on a POST

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -59,6 +59,7 @@ _.extend(Form.prototype, {
     },
     post: function (req, res, callback) {
         debug('Received POST for ' + req.path);
+        this.setErrors(null, req, res);
         this._process(req, res, function (err) {
             if (err) {
                 return callback(err);

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -226,6 +226,7 @@ describe('Form Controller', function () {
             });
             res = {};
             sinon.stub(Form.prototype, 'validate').yields(null);
+            sinon.stub(Form.prototype, 'setErrors');
             sinon.stub(Form.prototype, 'saveValues').yields(null);
             sinon.stub(Form.prototype, 'successHandler');
             _.each(validators, function (fn, key) {
@@ -235,6 +236,7 @@ describe('Form Controller', function () {
 
         afterEach(function () {
             Form.prototype.validate.restore();
+            Form.prototype.setErrors.restore();
             Form.prototype.saveValues.restore();
             Form.prototype.successHandler.restore();
             _.each(validators, function (fn, key) {
@@ -251,6 +253,11 @@ describe('Form Controller', function () {
                 'bool',
                 'options'
             ]);
+        });
+
+        it('sets errors to null', function () {
+            form.post(req, res, cb);
+            form.setErrors.should.have.been.calledWithExactly(null, req, res);
         });
 
         it('call callback with error if _process fails', function () {


### PR DESCRIPTION
If a user submits an invalid input, then tries again with an input that triggers an exit page then on going back, the previous error still exists on the session and so is displayed. Reset any saved errors on any POST to ensure that previous POST's errors are removed.