### PR TITLE
Allow for extensible render method

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -49,12 +49,13 @@ _.extend(Form.prototype, {
             if (_.isEmpty(this.options.fields) && this.options.next) {
                 this.emit('complete', req, res);
             }
-            res.render(this.options.template, _.extend({
+            _.extend(res.locals, {
                 errors: errors,
                 errorlist: _.map(errors, _.identity),
                 values: values,
                 options: this.options
-            }, this.locals(req, res)));
+            }, this.locals(req, res));
+            this.render(req, res, callback);
         }.bind(this));
     },
     post: function (req, res, callback) {
@@ -83,6 +84,9 @@ _.extend(Form.prototype, {
     },
     locals: function (/*req, res*/) {
         return {};
+    },
+    render: function (req, res/*, callback*/) {
+        res.render(this.options.template);
     },
     // placeholder methods for persisting error messages between POST and GET
     getErrors: function (/*req, res*/) {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -119,16 +119,19 @@ describe('Form Controller', function () {
                 path: '/index'
             });
             res = {
-                render: sinon.stub()
+                render: sinon.stub(),
+                locals: {}
             };
             cb = sinon.stub();
             sinon.stub(Form.prototype, 'getValues').yields(null, {});
             sinon.stub(Form.prototype, 'getErrors').returns({});
+            sinon.stub(Form.prototype, 'render');
         });
 
         afterEach(function () {
             Form.prototype.getValues.restore();
             Form.prototype.getErrors.restore();
+            Form.prototype.render.restore();
         });
 
         it('calls form.getValues', function () {
@@ -137,29 +140,23 @@ describe('Form Controller', function () {
             form.getValues.should.have.been.calledOn(form);
         });
 
-        it('renders the provided template', function () {
-            form = new Form({ template: 'test' });
+        it('calls form.render', function () {
             form.get(req, res, cb);
-            res.render.should.have.been.calledWith('test');
-        });
-
-        it('if path is "/" and no template is provided uses "index for template', function () {
-            form = new Form({ template: 'index' });
-            form.get(req, res, cb);
-            res.render.should.have.been.calledWith('index');
+            form.render.should.have.been.calledOnce;
+            form.render.should.have.been.calledWithExactly(req, res, cb);
         });
 
         it('passes any errors to the rendered template', function () {
             form.getErrors.returns({ field: { message: 'error' } });
             form.get(req, res, cb);
-            res.render.args[0][1].errors.should.eql({ field: { message: 'error' } });
+            res.locals.errors.should.eql({ field: { message: 'error' } });
         });
 
         it('passes output of getValues to the rendered template', function () {
             req.flash.returns([]);
             form.getValues.yields(null, { values: [1] });
             form.get(req, res, cb);
-            res.render.args[0][1].values.should.eql({ values: [1] });
+            res.locals.values.should.eql({ values: [1] });
         });
 
         it('calls callback with error if getValues fails', function () {
@@ -172,7 +169,7 @@ describe('Form Controller', function () {
 
         it('includes form options in rendered response', function () {
             form.get(req, res, cb);
-            res.render.args[0][1].options.should.eql(form.options);
+            res.locals.options.should.eql(form.options);
         });
 
         it('emits "complete" event if form has no fields', function () {
@@ -391,6 +388,31 @@ describe('Form Controller', function () {
                 cb.should.have.been.calledWith({ field: 'invalid' });
             });
 
+        });
+
+    });
+
+    describe('render', function () {
+
+        var form, req, res, cb;
+
+        beforeEach(function () {
+            form = new Form({
+                template: 'index',
+                next: '/next',
+                fields: {
+                    field: 'name'
+                }
+            });
+            res = {
+                render: sinon.stub()
+            };
+            cb = sinon.stub();
+        });
+
+        it('renders the provided template', function () {
+            form.render(req, res, cb);
+            res.render.should.have.been.calledWith('index');
         });
 
     });


### PR DESCRIPTION
In some instances we may wish to do something other than render an html template with the result of a form. This allow the render method alone to be extended without having to include all the other `get` functionality, which is unlikely to change.