### PR TITLE
Write values to req.form.values on GET

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -45,6 +45,7 @@ _.extend(Form.prototype, {
             if (err) {
                 return callback(err);
             }
+            req.form = { values: values };
             debug('Rendering form for ' + req.path);
             if (_.isEmpty(this.options.fields) && this.options.next) {
                 this.emit('complete', req, res);

--- a/lib/form.js
+++ b/lib/form.js
@@ -45,7 +45,7 @@ _.extend(Form.prototype, {
             if (err) {
                 return callback(err);
             }
-            req.form = { values: values };
+            req.form = { values: values || {} };
             debug('Rendering form for ' + req.path);
             if (_.isEmpty(this.options.fields) && this.options.next) {
                 this.emit('complete', req, res);

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -140,6 +140,12 @@ describe('Form Controller', function () {
             form.getValues.should.have.been.calledOn(form);
         });
 
+        it('sets values to req.form.values', function () {
+            Form.prototype.getValues.yields(null, { foo: 'bar' });
+            form.get(req, res, cb);
+            req.form.values.should.eql({ foo: 'bar' });
+        });
+
         it('calls form.render', function () {
             form.get(req, res, cb);
             form.render.should.have.been.calledOnce;

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -146,6 +146,12 @@ describe('Form Controller', function () {
             req.form.values.should.eql({ foo: 'bar' });
         });
 
+        it('defaults req.form.values to an empty object', function () {
+            Form.prototype.getValues.yields(null);
+            form.get(req, res, cb);
+            req.form.values.should.eql({ });
+        });
+
         it('calls form.render', function () {
             form.get(req, res, cb);
             form.render.should.have.been.calledOnce;


### PR DESCRIPTION
This ensures that form#locals can have access to the response from getValues when establishing extra vars to send to the template.