### PR TITLE
Allow per-field validation

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -18,6 +18,9 @@ var Form = function Form(options) {
     options.fields = options.fields || {};
     this.options = options;
     this.Error = ErrorClass;
+
+    this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
+    this.validator = dataValidator(this.options.fields);
 };
 
 util.inherits(Form, EventEmitter);
@@ -97,15 +100,10 @@ _.extend(Form.prototype, {
     _validate: function (req, res, callback) {
         debug('Validating...');
 
-        var formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
-
-        var validator = dataValidator(this.options.fields),
-            errors = {};
+        var errors = {};
 
         _.each(req.form.values, function (value, key) {
-            var emptyValue = formatter(key, '');
-
-            var error = validator(key, value, req.form.values, emptyValue);
+            var error = this.validateField(key, req);
             if (error) {
                 if (error.group) {
                     errors[error.group] = new this.Error(error.group, error);
@@ -123,6 +121,10 @@ _.extend(Form.prototype, {
     },
     validate: function (req, res, callback) {
         callback();
+    },
+    validateField: function (key, req) {
+        var emptyValue = this.formatter(key, '');
+        return this.validator(key, req.form.values[key], req.form.values, emptyValue);
     },
     _process: function (req, res, callback) {
         req.form = { values: {} };


### PR DESCRIPTION
There are occasions where we want to be able to validate a field by its configured rules outside of the _validate method.

Setting the formatter and validator methods on the instance prevents the overhead of recreating them for each request.