### PR TITLE
#5: Validators are not implicitly required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "iojs"
 notifications:
   email: false
+sudo: false

--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ All of these methods take three arguments of the request, the response and a cal
 * `locals` Define what additional variables a controller exposes to its template
 
 These methods are synchronous and take only the request and response obejct as arguments.
+
+### Validators
+
+The library [supports a number of validators](https://github.com/UKHomeOffice/passports-form-controller/blob/master/lib/validation/validators.js).
+
+By default the application of a validator is optional on empty strings. If you need to ensure that is validated as being 9 characters long and exists then you need to use both an `exactlength` and a `required` validator.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ These methods are synchronous and take only the request and response obejct as a
 
 The library [supports a number of validators](https://github.com/UKHomeOffice/passports-form-controller/blob/master/lib/validation/validators.js).
 
-By default the application of a validator is optional on empty strings. If you need to ensure that is validated as being 9 characters long and exists then you need to use both an `exactlength` and a `required` validator.
+By default the application of a validator is optional on empty strings. If you need to ensure a field is validated as being 9 characters long and exists then you need to use both an `exactlength` and a `required` validator.

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -47,7 +47,7 @@ module.exports = Validators = {
 
     equal: function equal(value) {
         var values = [].slice.call(arguments, 1);
-        return values.length && _.any(values, function (c) { return value === c || value === ''; });
+        return values.length && (value === '' || values.indexOf(value) > -1);
     },
 
     phonenumber: function phonenumber(value) {

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -1,5 +1,4 @@
-var moment = require('moment'),
-    _ = require('underscore');
+var moment = require('moment');
 
 // validator methods should return false (or falsy value) for *invalid* input
 // and true (or truthy value) for *valid* input.

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -21,20 +21,20 @@ module.exports = Validators = {
     },
 
     email: function email(value) {
-        return Validators.regex(value, /^[a-z0-9\._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,6}$/i);
+        return value === '' || Validators.regex(value, /^[a-z0-9\._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,6}$/i);
     },
 
     minlength: function minlength(value, length) {
         length = length || 0;
-        return Validators.string(value) && value.length >= length;
+        return Validators.string(value) && (value === '' || value.length >= length);
     },
 
     maxlength: function maxlength(value, length) {
-        return Validators.string(value) && value.length <= length;
+        return Validators.string(value) && (value === '' || value.length <= length);
     },
 
     exactlength: function exactlength(value, length) {
-        return Validators.string(value) && value.length === length;
+        return Validators.string(value) && (value === '' || value.length === length);
     },
 
     alphanum: function alphanum(value) {
@@ -42,24 +42,24 @@ module.exports = Validators = {
     },
 
     numeric: function numeric(value) {
-        return Validators.regex(value, /^\d+$/);
+        return Validators.regex(value, /^\d*$/);
     },
 
     equal: function equal(value) {
         var values = [].slice.call(arguments, 1);
-        return values.length && _.any(values, function (c) { return value === c; });
+        return values.length && _.any(values, function (c) { return value === c || value === ''; });
     },
 
     phonenumber: function phonenumber(value) {
-        return Validators.regex(value, /^\(?\+?[\d()-]{0,15}$/);
+        return value === '' || Validators.regex(value, /^\(?\+?[\d()-]{0,15}$/);
     },
 
     ukmobilephone: function ukmobilephone(value) {
-        return Validators.regex(value, /^(07)\d{9}$/);
+        return value === '' || Validators.regex(value, /^(07)\d{9}$/);
     },
 
     date: function date(value) {
-        return Validators.regex(value, /\d{4}\-\d{2}\-\d{2}/) && moment(value, dateFormat).isValid();
+        return value === '' || Validators.regex(value, /\d{4}\-\d{2}\-\d{2}/) && moment(value, dateFormat).isValid();
     },
 
     before: function before(value/*, [diff, unit][, diff, unit]*/) {
@@ -71,7 +71,7 @@ module.exports = Validators = {
             unit = args.shift() || 'years';
             date = date.add(diff, unit);
         }
-        return Validators.date(value) && date.isBefore(moment());
+        return value === '' || Validators.date(value) && date.isBefore(moment());
     },
 
     after: function after(value, date) {
@@ -89,11 +89,11 @@ module.exports = Validators = {
                 test = test.add(diff, unit);
             }
         }
-        return Validators.date(value) && test.isAfter(comparator);
+        return value === '' || Validators.date(value) && test.isAfter(comparator);
     },
 
     postcode: function postcode(value) {
-        return Validators.regex(value, /^([GIR] ?0[A]{2})|((([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) ?[0-9][A-Z]{2})$/i);
+        return value === '' || Validators.regex(value, /^([GIR] ?0[A]{2})|((([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) ?[0-9][A-Z]{2})$/i);
     }
 
 };

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -76,6 +76,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 't@i.co',
                 'test@example.com',
                 'test+suffix@gmail.com',
@@ -97,7 +98,6 @@ describe('Validators', function () {
             var inputs = [
                 [undefined, 1],
                 [100, 1],
-                ['', 1],
                 ['asdf', 10],
                 ['asdf', 5]
             ];
@@ -110,6 +110,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                ['', 9],
                 ['asdfasdfasdf', 10],
                 ['t']
             ];
@@ -141,6 +142,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                ['', 9],
                 ['asdfasdf', 10],
                 ['123', 4]
             ];
@@ -170,6 +172,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                ['', 9],
                 ['123', 3]
             ];
             _.each(inputs, function (i) {
@@ -200,6 +203,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                ['', 'Adam Smith'],
                 ['John Smith', 'John Smith'],
                 [10, 10],
                 [true, true],
@@ -234,6 +238,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 '123',
                 '123456',
                 '1234567890',
@@ -277,6 +282,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 '07812123456'
             ];
             _.each(inputs, function (i) {
@@ -308,6 +314,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 '1980-02-29'
             ];
             _.each(inputs, function (i) {
@@ -345,6 +352,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 '1980-02-29',
                 '2014-11-05',
                 ['2014-11-04', 1, 'day'],
@@ -392,6 +400,7 @@ describe('Validators', function () {
 
         describe('valid inputs', function () {
             var inputs = [
+                ['', '2014-12-15'],
                 ['2014-12-16', '2014-12-15'],
                 ['2014-11-05', 1, 'day'],
                 ['1993-11-06', 21, 'years'],
@@ -457,6 +466,7 @@ describe('Validators', function () {
 
         describe('valid values', function () {
             var inputs = [
+                '',
                 '1'
             ];
             _.each(inputs, function (i) {


### PR DESCRIPTION
See: https://github.com/UKHomeOffice/passports-form-controller/issues/5

By default the application of a validator is optional on empty strings. If you need to ensure a field is validated as being 9 characters long and exists then you need to use both an `exactlength` and a `required` validator.

In a couple of cases I amended a regex to no longer only match for more than one character but in other cases where the code was more complex I put an explicit check for an empty string since this it's easier to read.

The `regex` validator does not pass for an empty string by default as it would be bad to alter the expected behaviour (full control over what is being tested for with the possibility of making things required.)

All of the tests pass but these changes affect a large number of validators so tread carefully in terms of merging, and make sure that all of your non-optional fields have a `required` validator against them.