### PR TITLE
Fix missing validator error message

### DIFF
--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -25,7 +25,7 @@ function applyValidator(validator, value, key) {
     if (validators[validator.type]) {
         return validate();
     } else {
-        throw new Error('Undefined validator:', validator.type);
+        throw new Error('Undefined validator:' + validator.type);
     }
 }
 


### PR DESCRIPTION
The validator type needs to be appended to the message, not passed as an additional argument. Passing as an additional argument causes the type to be missed from error reporting and makes debugging harder.