### PR TITLE
Ensure form action is populated on res.locals

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -57,8 +57,10 @@ _.extend(Form.prototype, {
                 errors: errors,
                 errorlist: _.map(errors, _.identity),
                 values: values,
-                options: this.options
-            }, this.locals(req, res));
+                options: this.options,
+                action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
+            });
+            _.extend(res.locals, this.locals(req, res));
             this.render(req, res, callback);
         }.bind(this));
     },

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -116,7 +116,8 @@ describe('Form Controller', function () {
                 }
             });
             req = request({
-                path: '/index'
+                path: '/index',
+                baseUrl: '/base'
             });
             res = {
                 render: sinon.stub(),
@@ -200,6 +201,15 @@ describe('Form Controller', function () {
             delete form.options.next;
             form.get(req, res, cb);
             form.emit.withArgs('complete').should.not.have.been.called;
+        });
+
+        it('sets the action property on res.locals', function () {
+            form.get(req, res, cb);
+            res.locals.action.should.equal('/base/index');
+
+            req.baseUrl = '/';
+            form.get(req, res, cb);
+            res.locals.action.should.equal('/index');
         });
 
     });


### PR DESCRIPTION
Form action was being left blank before, which works in some cases as an action to the current URL, but can fail if the action is being read off via client-side javascript using getAttribute, so set it explicitly.