### PR TITLE
Implement form requestHandler as an express router

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
         "strict": 0,
         "no-mixed-requires": 0,
         "no-underscore-dangle": 0,
-        "no-shadow": 0
+        "no-shadow": 0,
+        "new-cap": 0
     }
 }

--- a/lib/form.js
+++ b/lib/form.js
@@ -21,26 +21,21 @@ var Form = function Form(options) {
 
     this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
     this.validator = dataValidator(this.options.fields);
+
+    this.router = require('express').Router();
 };
 
 util.inherits(Form, EventEmitter);
 
 _.extend(Form.prototype, {
     requestHandler: function () {
-        return function (req, res, callback) {
-            var method = req.method.toLowerCase();
-            if (typeof this[method] === 'function') {
-                this[method](req, res, function (err) {
-                    if (err) {
-                        this.errorHandler(err, req, res, callback);
-                    } else {
-                        callback();
-                    }
-                }.bind(this));
-            } else {
-                res.send(405, 'Method ' + method + ' not allowed.');
-            }
-        }.bind(this);
+        this.router.get('/', this.get.bind(this));
+        this.router.post('/', this.post.bind(this));
+        this.router.use(this.errorHandler.bind(this));
+        return this.router;
+    },
+    use: function () {
+        this.router.use.apply(this.router, arguments);
     },
     get: function (req, res, callback) {
         var errors = this.getErrors(req, res);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/UKHomeOffice/passports-form-controller",
   "dependencies": {
     "debug": "^2.1.1",
+    "express": "^4.12.3",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
This allow constructors to add middleware to the stack to be called before request handling using a familiar API - e.g. `use`

An example of this is in the renewal journey where the app submission needs to be checked before serving pages. It will also allow a clean-up of the photo errors model instantiation in the photo journey.

## Example:

``` javascript
function MyForm() {
  Form.call(this);
  this.use(require('./my-middleware');
  // my-middlware will now be called before any request handlers
}

util.inherits(MyForm, Form);
```