### PR TITLE
Add support for null/not a function method handlers

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -29,8 +29,18 @@ util.inherits(Form, EventEmitter);
 
 _.extend(Form.prototype, {
     requestHandler: function () {
-        this.router.get('/', this.get.bind(this));
-        this.router.post('/', this.post.bind(this));
+        var methods = ['get', 'post', 'put', 'delete'];
+        _.each(methods, function (method) {
+            if (typeof this[method] === 'function') {
+                this.router[method]('/', this[method].bind(this));
+            } else {
+                this.router[method]('/', function (req, res, next) {
+                    var err = new Error('Method not supported');
+                    err.statusCode = 405;
+                    next(err);
+                });
+            }
+        }, this);
         this.router.use(this.errorHandler.bind(this));
         return this.router;
     },

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -104,6 +104,15 @@ describe('Form Controller', function () {
                 });
             });
 
+            it('throws a 405 on unsupported methods', function (done) {
+                req.method = 'PUT';
+                handler = form.requestHandler();
+                handler(req, res, function (err) {
+                    err.statusCode.should.equal(405);
+                    done();
+                });
+            });
+
         });
 
     });


### PR DESCRIPTION
In some instances the `post` or `get` handlers are set to null, which currently throws an error trying to bind. Instead add a default handler that calls back with a 405 error.