### PR TITLE
Do not overwrite params from parent routers in form request handler

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -22,7 +22,7 @@ var Form = function Form(options) {
     this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
     this.validator = dataValidator(this.options.fields);
 
-    this.router = require('express').Router();
+    this.router = require('express').Router({ mergeParams: true });
 };
 
 util.inherits(Form, EventEmitter);

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -105,6 +105,22 @@ describe('Form Controller', function () {
                 });
             });
 
+            it('keeps url params from parent routers', function (done) {
+                req.method = 'GET';
+                req.url = '/test/123';
+                var router = require('express').Router();
+                form.use(function (req, res, next) {
+                    try {
+                        req.params.id.should.equal('123');
+                        next();
+                    } catch(e) {
+                        done(e);
+                    }
+                });
+                router.route('/test/:id').all(form.requestHandler());
+                router(req, res, done);
+            });
+
             it('throws a 405 on unsupported methods', function (done) {
                 req.method = 'PUT';
                 handler = form.requestHandler();


### PR DESCRIPTION
If the form has been bound onto a route with a parameterised path - e.g. /path/:param - then these params should be exposed to the form methods to access. This means using the mergeParams option on the form's own router to ensure it keep any pre-existing values on req.params instead of instantiating an empty params object.