### PR TITLE
Convert the get and post methods to use middleware chains instead of nested callbacks

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -1,4 +1,6 @@
+/*eslint no-unused-vars: [2, {"vars": "all", "args": "none"}]*/
 var util = require('util'),
+    express = require('express'),
     EventEmitter = require('events').EventEmitter;
 
 var _ = require('underscore'),
@@ -22,7 +24,7 @@ var Form = function Form(options) {
     this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
     this.validator = dataValidator(this.options.fields);
 
-    this.router = require('express').Router({ mergeParams: true });
+    this.router = express.Router({ mergeParams: true });
 };
 
 util.inherits(Form, EventEmitter);
@@ -48,57 +50,58 @@ _.extend(Form.prototype, {
         this.router.use.apply(this.router, arguments);
     },
     get: function (req, res, callback) {
-        var errors = this.getErrors(req, res);
-        this._getValues(req, res, function (err, values) {
-            if (err) {
-                return callback(err);
-            }
-            req.form = { values: values || {} };
-            debug('Rendering form for ' + req.path);
-            if (_.isEmpty(this.options.fields) && this.options.next) {
-                this.emit('complete', req, res);
-            }
-            _.extend(res.locals, {
-                errors: errors,
-                errorlist: _.map(errors, _.identity),
-                values: values,
-                options: this.options,
-                action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
-            });
-            _.extend(res.locals, this.locals(req, res));
-            this.render(req, res, callback);
-        }.bind(this));
+        req.form = req.form || {};
+        var router = express.Router({ mergeParams: true });
+        router.use([
+            this._getErrors.bind(this),
+            this._getValues.bind(this),
+            this._locals.bind(this),
+            this.render.bind(this)
+        ]);
+        router.use(function (err, req, res, next) {
+            callback(err);
+        });
+        if (_.isEmpty(this.options.fields) && this.options.next) {
+            this.emit('complete', req, res);
+        }
+        router.handle(req, res, callback);
     },
     post: function (req, res, callback) {
-        debug('Received POST for ' + req.path);
         this.setErrors(null, req, res);
-        this._process(req, res, function (err) {
-            if (err) {
-                return callback(err);
-            }
-            this._validate(req, res, function (err) {
-                if (err) {
-                    debug('Validation failed for ' + req.path);
-                    debug(err);
-                    callback(err);
-                } else {
-                    debug('Validation passed for ' + req.path);
-                    this.saveValues(req, res, function (err) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            this.successHandler(req, res);
-                        }
-                    }.bind(this));
-                }
-            }.bind(this));
-        }.bind(this));
+
+        req.form = req.form || {};
+        var router = express.Router({ mergeParams: true });
+        router.use([
+            this._process.bind(this),
+            this._validate.bind(this),
+            this.saveValues.bind(this),
+            this.successHandler.bind(this)
+        ]);
+        router.use(function (err, req, res, next) {
+            callback(err);
+        });
+        router.handle(req, res, callback);
+    },
+    _locals: function (req, res, callback) {
+        _.extend(res.locals, {
+            errors: req.form.errors,
+            errorlist: _.map(req.form.errors, _.identity),
+            values: req.form.values,
+            options: this.options,
+            action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
+        });
+        _.extend(res.locals, this.locals(req, res));
+        callback();
     },
     locals: function (/*req, res*/) {
         return {};
     },
-    render: function (req, res/*, callback*/) {
+    render: function (req, res, callback) {
         res.render(this.options.template);
+    },
+    _getErrors: function (req, res, callback) {
+        req.form.errors = this.getErrors(req, res);
+        callback();
     },
     // placeholder methods for persisting error messages between POST and GET
     getErrors: function (/*req, res*/) {
@@ -146,7 +149,10 @@ _.extend(Form.prototype, {
         callback();
     },
     _getValues: function (req, res, callback) {
-        this.getValues(req, res, callback);
+        this.getValues(req, res, function (err, values) {
+            req.form.values = values || {};
+            callback(err);
+        });
     },
     getValues: function (req, res, callback) {
         callback();

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -187,7 +187,7 @@ describe('Form Controller', function () {
         it('calls form.render', function () {
             form.get(req, res, cb);
             form.render.should.have.been.calledOnce;
-            form.render.should.have.been.calledWithExactly(req, res, cb);
+            form.render.should.have.been.calledWith(req, res);
         });
 
         it('passes any errors to the rendered template', function () {
@@ -206,7 +206,7 @@ describe('Form Controller', function () {
             form.getValues.yields({ error: 'message' });
             form.get(req, res, cb);
             cb.should.have.been.calledOnce;
-            cb.should.have.been.calledWithExactly({ error: 'message' });
+            cb.should.have.been.calledWith({ error: 'message' });
         });
 
         it('includes form options in rendered response', function () {


### PR DESCRIPTION
This reduces the amount of `if (err) { return callback(err); }` that was littering the code, and makes the request pipeline a lot easier to understand.