### PR TITLE
Fix postcode regex

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -92,7 +92,7 @@ module.exports = Validators = {
     },
 
     postcode: function postcode(value) {
-        return value === '' || Validators.regex(value, /^([GIR] ?0[A]{2})|((([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) ?[0-9][A-Z]{2})$/i);
+        return value === '' || Validators.regex(value, /^(([GIR] ?0[A]{2})|((([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) ?[0-9][A-Z]{2}))$/i);
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "csv": "^0.4.1",
     "eslint": "^0.14.1",
     "mocha": "^2.1.0",
-    "postcode": "^0.2.2",
+    "postcode": "0.2.2",
     "reqres": "^1.1.1",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.6.0"

--- a/test/spec/spec.postcode-validation.js
+++ b/test/spec/spec.postcode-validation.js
@@ -34,4 +34,11 @@ describe('Postcode validation - loads full UK postcode database, may take some t
         });
     });
 
+    it('correctly rejects invalid postcodes', function () {
+
+        Validators.postcode('A11AA A11AA').should.not.be.ok;
+        Validators.postcode('N443 6DFG').should.not.be.ok;
+
+    });
+
 });


### PR DESCRIPTION
A missing set of parentheses in the postcode regex causes the postcode test to be too loose at it allows any partial postcode match to be valid instead of insisting that the entire postcode is valid. In particular it allows a valid psotcode appended to itself to still be valid.

Wrapping the entire regex in parens - `^(...)$` forces the whole postcode to match.