### PR TITLE
Only validate a dependent field if the dependency exists in the current fields object.

### DIFF
--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -42,7 +42,7 @@ function validator(fields) {
                     value: true
                 };
             }
-            if (!dependent || (dependent && values[dependent.field] === dependent.value)) {
+            if (!dependent || (dependent && !fields[dependent.field]) || (dependent && values[dependent.field] === dependent.value)) {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
There is now a case where one field is used in two different steps. In one of these steps the field is always required, in the other, it's only required if another field in the step has a particular value.