### PR TITLE
Validation redirects

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -125,7 +125,14 @@ _.extend(Form.prototype, {
         }, this);
 
         if (!_.isEmpty(errors)) {
-            callback(errors);
+            var nonRedirectErrors = _.pick(errors, function(error) {
+                return !error.redirect;
+            });
+            if (!_.isEmpty(nonRedirectErrors)) {
+                callback(nonRedirectErrors);
+            } else {
+                callback(errors);
+            }
         } else {
             this.validate(req, res, callback);
         }

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -801,6 +801,66 @@ describe('Form Controller', function () {
 
         });
 
+        describe('validators with redirects', function () {
+
+            var form, req, res, cb;
+
+            beforeEach(function () {
+                form = new Form({
+                    template: 'index',
+                    fields: {
+                        'is-thing-a': {
+                            validate: 'required'
+                        },
+                        'is-thing-b': {
+                            validate: [
+                                { type: 'required', redirect: '/exit-page' }
+                            ]
+                        },
+                        'is-thing-c': {
+                            validate: 'required'
+                        }
+                    }
+                });
+                res = {};
+                cb = sinon.stub();
+            });
+
+            it('only calls callback with errors that don\'t have a redirect value if they exist', function () {
+                req = request({
+                    form: {
+                        values: {
+                            'is-thing-a': '',
+                            'is-thing-b': '',
+                            'is-thing-c': '',
+                        }
+                    }
+                });
+                form._validate(req, res, cb);
+                cb.should.be.calledWith({
+                    'is-thing-a': new form.Error('is-thing-a', { type: 'required' }),
+                    'is-thing-c': new form.Error('is-thing-c', { type: 'required' })
+                });
+            });
+
+            it('calls callback with all errors if they all contain a redirect value', function () {
+                req = request({
+                    form: {
+                        values: {
+                            'is-thing-a': 'value',
+                            'is-thing-b': '',
+                            'is-thing-c': 'value'
+                        }
+                    }
+                });
+                form._validate(req, res, cb);
+                cb.should.have.been.calledWith({
+                    'is-thing-b': new form.Error('is-thing-b', { type: 'required', redirect: '/exit-page' })
+                });
+            });
+
+        });
+
     });
 
 });


### PR DESCRIPTION
Before redirecting a user to an exit page after a validation failure we should show them validation failures for other fields within the current step.

A user should only be redirected to an exit page if all other fields within the step are valid.