### PR TITLE
Error redirection

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -169,11 +169,14 @@ _.extend(Form.prototype, {
     },
     getErrorStep: function (err, req) {
         var redirect = req.path;
-        var redirectedError = _.find(err, function (error) {
+        var redirectError = _.all(err, function (error) {
             return error.redirect;
         });
-        if (redirectedError) {
-            redirect = redirectedError.redirect;
+
+        if (redirectError) {
+            redirect = _.find(err, function (error) {
+                return error.redirect;
+            }).redirect;
         }
         if (req.baseUrl !== '/') {
             redirect = req.baseUrl + redirect;

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -535,7 +535,16 @@ describe('Form Controller', function () {
             res.redirect.should.have.been.calledWith('/index');
         });
 
-        it('redirects to error redirect if any error has a redirect property', function () {
+        it('redirects to req.path if not all errors have a redirect value', function () {
+            err = {
+                'field-a': new Form.Error('field-a'),
+                'field-b': new Form.Error('field-b', { redirect: '/exitpage' })
+            };
+            form.errorHandler(err, req, res);
+            res.redirect.should.have.been.calledWith('/index');
+        });
+
+        it('redirects to error redirect if all errors have a redirect value', function () {
             err.redirect = '/exitpage';
             form.errorHandler({ field: err }, req, res);
             res.redirect.should.have.been.calledWith('/exitpage');


### PR DESCRIPTION
Only redirect users to error redirect if all errors have a redirect value. If there are other validation errors, let the user correct these first.