### PR TITLE
Pass the request object into error classes on instantiation

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 
-function FormError(key, options) {
+function FormError(key, options/*, req*/) {
     options = _.extend({
         type: 'default'
     }, options);

--- a/lib/form.js
+++ b/lib/form.js
@@ -117,9 +117,9 @@ _.extend(Form.prototype, {
             var error = this.validateField(key, req);
             if (error) {
                 if (error.group) {
-                    errors[error.group] = new this.Error(error.group, error);
+                    errors[error.group] = new this.Error(error.group, error, req);
                 } else {
-                    errors[error.key] = new this.Error(error.key, error);
+                    errors[error.key] = new this.Error(error.key, error, req);
                 }
             }
         }, this);

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -1,0 +1,17 @@
+var ErrorClass = require('../../lib/error');
+
+var _ = require('underscore');
+
+describe('Error', function () {
+
+    it ('sets its key property to the key passed', function () {
+        var err = new ErrorClass('field', { type: 'type' });
+        err.key.should.equal('field');
+    });
+
+    it ('sets its key property to the type option passed', function () {
+        var err = new ErrorClass('field', { type: 'type' });
+        err.type.should.equal('type');
+    });
+
+});

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -433,6 +433,29 @@ describe('Form Controller', function () {
                 validators.email.should.not.have.been.called;
             });
 
+            it('creates instances of Error class with validation errors', function (done) {
+                validators.required.returns(false);
+                req.body = { field: 'value', email: 'foo', name: 'John' };
+                form.post(req, res, function (err) {
+                    _.each(err, function (e) {
+                        e.should.be.an.instanceOf(form.Error);
+                    });
+                    done();
+                });
+            });
+
+            it('passes the request object into error constructor', function (done) {
+                sinon.stub(form, 'Error');
+                validators.required.returns(false);
+                req.body = { field: 'value', email: 'foo', name: 'John' };
+                form.post(req, res, function (err) {
+                    form.Error.should.have.been.calledWithExactly('field', sinon.match({ type: 'required' }), req);
+                    form.Error.should.have.been.calledWithExactly('email', sinon.match({ type: 'required' }), req);
+                    form.Error.should.have.been.calledWithExactly('name', sinon.match({ type: 'required' }), req);
+                    done();
+                });
+            });
+
         });
 
         describe('invalid form-level validation', function () {


### PR DESCRIPTION
This is to support message translation based on request parameters

Part of a larger piece of exposing the translate methods on req to places that need to translate things. This will afford greater power to custom error classes.