### PR TITLE
Fix issue with before and after date validators.

### DIFF
--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -82,7 +82,7 @@ module.exports = Validators = {
             unit = args.shift() || 'years';
             date = date.add(diff, unit);
         }
-        return value === '' || Validators.date(value) && date.isBefore(moment());
+        return value === '' || Validators.date(value) && (date.isBefore(moment()) || date.isSame(moment()));
     },
 
     after: function after(value, date) {
@@ -100,7 +100,7 @@ module.exports = Validators = {
                 test = test.add(diff, unit);
             }
         }
-        return value === '' || Validators.date(value) && test.isAfter(comparator);
+        return value === '' || Validators.date(value) && (test.isAfter(comparator) || test.isSame(comparator));
     },
 
     postcode: function postcode(value) {

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -485,7 +485,6 @@ describe('Validators', function () {
         describe('invalid values', function () {
             var inputs = [
                 '2014-11-05',
-                ['2014-12-16', '2014-12-16'],
                 ['2013-12-15', '2013-12-16'],
                 ['2014-11-04', 1, 'day'],
                 ['1993-11-05', 21, 'years'],
@@ -506,6 +505,7 @@ describe('Validators', function () {
         describe('valid inputs', function () {
             var inputs = [
                 ['', '2014-12-15'],
+                ['2014-12-16', '2014-12-16'],
                 ['2014-12-16', '2014-12-15'],
                 ['2014-11-05', 1, 'day'],
                 ['1993-11-06', 21, 'years'],


### PR DESCRIPTION
Currently if we specify that a date must be before '1901-01-01' then 1901-01-01 is
    included as an invalid date. This also applies to the after validator.
    This fix makes it so that the specificed date is included as a valid date.