### PR TITLE
Pass the reponse object into the ErrorClass constructor

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 
-function FormError(key, options/*, req*/) {
+function FormError(key, options, req, res) {
     options = _.extend({
         type: 'default'
     }, options);
@@ -10,12 +10,12 @@ function FormError(key, options/*, req*/) {
     Object.defineProperty(this, 'message', {
         enumerable: true,
         get: function () {
-            return options.message || this.getMessage(key, options);
+            return options.message || this.getMessage(key, options, req, res);
         }
     });
 }
 
-FormError.prototype.getMessage = function (/*key, options*/) {
+FormError.prototype.getMessage = function (/*key, options, req, res*/) {
     return 'Error';
 };
 

--- a/lib/form.js
+++ b/lib/form.js
@@ -117,9 +117,9 @@ _.extend(Form.prototype, {
             var error = this.validateField(key, req);
             if (error) {
                 if (error.group) {
-                    errors[error.group] = new this.Error(error.group, error, req);
+                    errors[error.group] = new this.Error(error.group, error, req, res);
                 } else {
-                    errors[error.key] = new this.Error(error.key, error, req);
+                    errors[error.key] = new this.Error(error.key, error, req, res);
                 }
             }
         }, this);

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -4,6 +4,18 @@ var _ = require('underscore');
 
 describe('Error', function () {
 
+    var req, res;
+
+    beforeEach(function () {
+        req = request({});
+        res = {};
+        sinon.stub(ErrorClass.prototype, 'getMessage').returns('Error');
+    });
+
+    afterEach(function () {
+        ErrorClass.prototype.getMessage.restore();
+    });
+
     it ('sets its key property to the key passed', function () {
         var err = new ErrorClass('field', { type: 'type' });
         err.key.should.equal('field');
@@ -12,6 +24,18 @@ describe('Error', function () {
     it ('sets its key property to the type option passed', function () {
         var err = new ErrorClass('field', { type: 'type' });
         err.type.should.equal('type');
+    });
+
+    it('sets a default message', function () {
+        var options = { type: 'type' };
+        var err = new ErrorClass('field', options, req, res);
+        err.message.should.equal('Error');
+        ErrorClass.prototype.getMessage.should.have.been.calledWithMatch('field', options, req, res);
+    });
+
+    it('allows a custom message', function () {
+        var err = new ErrorClass('field', { message: 'My message' });
+        err.message.should.equal('My message');
     });
 
 });

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -444,14 +444,14 @@ describe('Form Controller', function () {
                 });
             });
 
-            it('passes the request object into error constructor', function (done) {
+            it('passes request and response objects into error constructor', function (done) {
                 sinon.stub(form, 'Error');
                 validators.required.returns(false);
                 req.body = { field: 'value', email: 'foo', name: 'John' };
                 form.post(req, res, function (err) {
-                    form.Error.should.have.been.calledWithExactly('field', sinon.match({ type: 'required' }), req);
-                    form.Error.should.have.been.calledWithExactly('email', sinon.match({ type: 'required' }), req);
-                    form.Error.should.have.been.calledWithExactly('name', sinon.match({ type: 'required' }), req);
+                    form.Error.should.have.been.calledWithExactly('field', sinon.match({ type: 'required' }), req, res);
+                    form.Error.should.have.been.calledWithExactly('email', sinon.match({ type: 'required' }), req, res);
+                    form.Error.should.have.been.calledWithExactly('name', sinon.match({ type: 'required' }), req, res);
                     done();
                 });
             });


### PR DESCRIPTION
Pass the reponse object to the getMessage method so that it can be used for error message construction. This will allow errors that use properties of `res.locals` to be built correctly.