### PR TITLE
Expose result of fork conditional

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -165,6 +165,9 @@ _.extend(Form.prototype, {
         if (req.baseUrl !== '/') {
             next = req.baseUrl + next;
         }
+        if (req.method !== 'POST') {
+            return next;
+        }
         var forks = this.options.forks || [];
 
         function evalCondition(condition) {
@@ -175,10 +178,18 @@ _.extend(Form.prototype, {
 
         // If a fork condition is met, its target supercedes the next property
         return forks.reduce(function (result, value) {
+
+            var conditionSatisfied = evalCondition(value.condition);
+
+            req.forkTaken = {
+                validate: conditionSatisfied ? value.target : this.options.next,
+                invalidate: conditionSatisfied ? this.options.next : value.target
+            };
+
             return evalCondition(value.condition) ?
                 req.baseUrl + value.target :
                 result;
-        }, next);
+        }.bind(this), next);
     },
     getErrorStep: function (err, req) {
         var redirect = req.path;
@@ -209,8 +220,9 @@ _.extend(Form.prototype, {
         }
     },
     successHandler: function (req, res) {
+        var nextStep = this.getNextStep(req, res);
         this.emit('complete', req, res);
-        res.redirect(this.getNextStep(req, res));
+        res.redirect(nextStep);
     }
 });
 

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -524,6 +524,10 @@ describe('Form Controller', function () {
 
         describe('forking journeys', function () {
 
+            beforeEach(function () {
+                req.method = 'POST';
+            });
+
             it('returns the fork target if the condition config is met', function () {
                 req.form.values['example-radio'] = 'conditionMet';
                 form.options.forks = [{


### PR DESCRIPTION
* added a forkTaken object to req
* if fork condition is met, the fork target is set as forkTaken.validate and `next` is passed as invalidate
* if fork condition is not met, the fork target is passed as forkTaken.invalidate and `mext` is passed as validate.
* changed order of events in successHandler - exec getNextStep before emitting complete so this can be hooked into in wizard check-progress middleware