### PR TITLE
Abstract forking logic.

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -160,13 +160,7 @@ _.extend(Form.prototype, {
     saveValues: function (req, res, callback) {
         callback();
     },
-    getNextStep: function (req, res) {
-        var next = this.options.next || req.path;
-        if (req.baseUrl !== '/') {
-            next = req.baseUrl + next;
-        }
-        var forks = this.options.forks || [];
-
+    _getForkTarget: function (req, res) {
         function evalCondition(condition) {
             return _.isFunction(condition) ?
                 condition(req, res) :
@@ -174,11 +168,24 @@ _.extend(Form.prototype, {
         }
 
         // If a fork condition is met, its target supercedes the next property
-        return forks.reduce(function (result, value) {
+        return this.options.forks.reduce(function (result, value) {
             return evalCondition(value.condition) ?
-                req.baseUrl + value.target :
+                value.target :
                 result;
-        }, next);
+        }, this.options.next);
+    },
+    getForkTarget: function (req, res) {
+        return this._getForkTarget(req, res);
+    },
+    getNextStep: function (req, res) {
+        var next = this.options.next || req.path;
+        if (this.options.forks && Array.isArray(this.options.forks)) {
+            next = this._getForkTarget(req, res);
+        }
+        if (req.baseUrl !== '/') {
+            next = req.baseUrl + next;
+        }
+        return next;
     },
     getErrorStep: function (err, req) {
         var redirect = req.path;


### PR DESCRIPTION
Sometimes we want to extend the getNextStep method and this means there is no way to get the unaltered result of a forking conditional. A specific case is when we override getNextStep to append /edit and redirect to the /confirm page. As forking conditionals are used for step invalidation in this case the rest of the form is invalidated rather than just skiping to the confirm step.

* Added new _getForkTarget method which executes forking logic. This is called in getNextStep so the result of just calling controller.getNextStep will be the same as before