### PR TITLE
Only create a validate array on a field object when necessary

### DIFF
--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -32,13 +32,12 @@ function applyValidator(validator, value, key) {
 function validator(fields) {
 
     _.each(fields, function (field, key) {
-        fields[key].validate = fields[key].validate || [];
-
         if (typeof fields[key].validate === 'string') {
             fields[key].validate = [fields[key].validate];
         }
 
         if (fields[key].options) {
+            fields[key].validate = fields[key].validate || [];
             fields[key].validate.push({
                 type: 'equal',
                 arguments: _.map(fields[key].options, function (o) {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -266,6 +266,7 @@ describe('Form Controller', function () {
                     field: { formatter: 'uppercase', validate: 'required' },
                     email: { validate: ['required', 'email'] },
                     name: { validate: ['required', { type: 'minlength', arguments: [10] }, { type: 'maxlength', arguments: 20 }] },
+                    place: { validate: 'required' },
                     bool: { formatter: 'boolean' },
                     options: { options: [ 'one', { value: 'two' }, 'three' ] }
                 }
@@ -329,6 +330,7 @@ describe('Form Controller', function () {
                 'field',
                 'email',
                 'name',
+                'place',
                 'bool',
                 'options'
             ]);
@@ -351,6 +353,13 @@ describe('Form Controller', function () {
             form.post(req, res, cb);
             req.form.values.field.should.equal('VALUE');
             req.form.values.bool.should.equal(true);
+        });
+
+        it('creates a validate array when validate is a string or field options exist', function () {
+            form.post(req, res, cb);
+            expect(form.options.fields.bool.validate).to.be.undefined;
+            form.options.fields.place.validate.should.eql(['required']);
+            form.options.fields.options.validate.length.should.equal(1);
         });
 
         it('validates the fields', function () {
@@ -467,7 +476,7 @@ describe('Form Controller', function () {
                 req.body = { field: 'value', email: 'foo', name: 'John' };
                 form.post(req, res, cb);
                 cb.should.have.been.calledOnce;
-                Object.keys(cb.args[0][0]).should.eql(['field', 'email', 'name']);
+                Object.keys(cb.args[0][0]).should.eql(['field', 'email', 'name', 'place']);
                 _.each(cb.args[0][0], function (err, key) {
                     err.type.should.equal('required');
                     err.key.should.equal(key);


### PR DESCRIPTION
Instead of defaulting a `validate` property on a field object to an empty array leave it as undefined. Only create an array if `validate` is a string or there are fields options that should be validated against.