### PR TITLE
Allow external links in redirects during failed validation

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -198,7 +198,7 @@ _.extend(Form.prototype, {
                 return error.redirect;
             }).redirect;
         }
-        if (req.baseUrl !== '/') {
+        if (req.baseUrl !== '/' && !redirect.match(/^https?:\/\//)) {
             redirect = req.baseUrl + redirect;
         }
         return redirect;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "cover": "istanbul cover _mocha -- -R dot --recursive test/spec/ --require test/helper --timeout 300000",
     "check-coverage": "istanbul check-coverage --statement 98.31 --branch 94.89 --function 96.30 --line 98.31",
     "lint": "eslint .",
-    "snyk": "snyk test --dev"
+    "snyk": "snyk test",
+    "snyk:dev": "snyk test --dev"
   },
   "repository": {
     "type": "git",

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -808,6 +808,20 @@ describe('Form Controller', function () {
             res.redirect.should.have.been.calledWith('/foo/index');
         });
 
+        it('redirects to another site if defined', function () {
+            err.redirect = 'http://www.gov.uk/';
+            req.baseUrl = '/foo';
+            form.errorHandler({ field: err }, req, res);
+            res.redirect.should.have.been.calledWith('http://www.gov.uk/');
+        });
+
+        it('redirects to another secure site if defined', function () {
+            err.redirect = 'https://www.gov.uk/';
+            req.baseUrl = '/foo';
+            form.errorHandler({ field: err }, req, res);
+            res.redirect.should.have.been.calledWith('https://www.gov.uk/');
+        });
+
         it('calls callback if error is not a validation error', function () {
             var cb = sinon.stub();
             var err = new Error('message');


### PR DESCRIPTION
When an app is mounted on a `baseUrl` and redirects when validation fails, the baseUrl is added to the `redirect` property when it isn't '/'. This shouldn't happen when redirecting to another site. Add a check for http/s when adding 'baseUrl' so that the redirect property isn't prefixed when the redirect is another site.