### PR TITLE
closes #50 - support custom validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ The library [supports a number of validators](https://github.com/UKHomeOffice/pa
 
 By default the application of a validator is optional on empty strings. If you need to ensure a field is validated as being 9 characters long and exists then you need to use both an `exactlength` and a `required` validator.
 
+#### Custom Validators
+
+Custom validator functions can be passed in field config. These must be named functions and the name is used as the error.type for looking up validation error messages.
+
+fields.js
+```js
+{
+    'field-1': {
+        validate: ['required', function isTrue(val) {
+            return val === true;
+        }]
+    }
+}
+```
+
 ### steps config
 
 #### Handles journey forking

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -17,6 +17,13 @@ function applyValidator(validator, value, key) {
         }
     }
 
+    function customValidate() {
+        debug('Applying custom %s validator with value %s', validator.name, value);
+        if (!validator(value)) {
+            return _.extend({ key: key }, { type: validator.name });
+        }
+    }
+
     if (typeof validator === 'string') {
         validator = {
             type: validator
@@ -24,6 +31,12 @@ function applyValidator(validator, value, key) {
     }
     if (validators[validator.type]) {
         return validate();
+    } else if (typeof validator === 'function') {
+        if (validator.name) {
+            return customValidate();
+        } else {
+            throw new Error('Custom validator needs to be a named function');
+        }
     } else {
         throw new Error('Undefined validator:' + validator.type);
     }

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -1,4 +1,5 @@
 var Validators = require('../../').validators;
+var validationHelper = require('../../lib/validation');
 var _ = require('underscore');
 
 function testName(input) {
@@ -582,6 +583,59 @@ describe('Validators', function () {
             });
         });
 
+    });
+
+    describe('custom validators', function () {
+        var fields, validator;
+
+        beforeEach(function () {
+            fields = {
+                'field-1': {
+                    validate: [function doSomething() {
+                        return true;
+                    }]
+                },
+                'field-2': {
+                    validate: [function () {
+                        return true;
+                    }]
+                },
+                'field-3': {
+                    validate: [function fail() {
+                        return false;
+                    }]
+                },
+                'field-4': {
+                    validate: [function checkVal(val) {
+                        return val === true;
+                    }]
+                }
+            };
+            validator = validationHelper(fields);
+        });
+
+        it('accepts custom validators', function () {
+            expect(validator('field-1', null)).to.be.undefined;
+        });
+
+        it('throws an error if an anonymous function is passed', function () {
+            try {
+                validator('field-2');
+            } catch (err) {
+                err.should.be.an('error')
+                    .and.have.property('message')
+                    .and.be.equal('Custom validator needs to be a named function');
+            }
+        });
+
+        it('uses the name of the function as the error type', function () {
+            validator('field-3').should.have.property('type')
+                .and.be.equal('fail');
+        });
+
+        it('validates using the passed values', function () {
+            expect(validator('field-4', true)).to.be.undefined;
+        });
     });
 
 });


### PR DESCRIPTION
* Allow end developer to supply a custom named validator for a field
* Accepts a named function, name is used to display validation error message