### PR TITLE
Fixes issue #52

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -13,6 +13,12 @@ function FormError(key, options, req, res) {
             return options.message || this.getMessage(key, options, req, res);
         }
     });
+    Object.defineProperty(this, 'title', {
+        enumerable: true,
+        get: function () {
+            return options.title || 'Oops, something went wrong';
+        }
+    });
 }
 
 FormError.prototype.getMessage = function (/*key, options, req, res*/) {

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -35,5 +35,10 @@ describe('Error', function () {
         var err = new ErrorClass('field', { message: 'My message' });
         err.message.should.equal('My message');
     });
+    
+    it('allows a custom title', function() {
+        var err = new ErrorClass('field', { title: 'My error title' });
+        err.title.should.equal('My error title');
+    });
 
 });


### PR DESCRIPTION
The possibility of adding a custom title in the `Error` controller is useful and seems to be implied in other parts of the codebase. Nonetheless, the current controller doesn't persist such property.