### PR TITLE
Fixes issue #52

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -13,10 +13,20 @@ function FormError(key, options, req, res) {
             return options.message || this.getMessage(key, options, req, res);
         }
     });
+    Object.defineProperty(this, 'title', {
+        enumerable: true,
+        get: function () {
+            return options.title || this.getTitle(key, options, req, res);
+        }
+    });
 }
 
 FormError.prototype.getMessage = function (/*key, options, req, res*/) {
     return 'Error';
+};
+
+FormError.prototype.getTitle = function (/*key, options, req, res*/) {
+    return 'Oops, something went wrong';
 };
 
 module.exports = FormError;

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -36,4 +36,14 @@ describe('Error', function () {
         err.message.should.equal('My message');
     });
 
+    it('allows a custom title', function () {
+        var err = new ErrorClass('field', { title: 'My error title' });
+        err.title.should.equal('My error title');
+    });
+
+    it('has a default title', function () {
+        var err = new ErrorClass('field', {});
+        err.title.should.exist;
+    });
+
 });


### PR DESCRIPTION
The possibility of adding a custom title in the `Error` controller is useful and seems to be implied in other parts of the codebase. Nonetheless, the current controller doesn't persist such property.
