### PR TITLE
Allow missing template on init

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -14,7 +14,7 @@ var Form = function Form(options) {
         throw new Error('Options must be provided');
     }
     if (!options.template) {
-        throw new Error('A template must be provided');
+        debug('No template provided');
     }
     options.defaultFormatters = options.defaultFormatters || ['trim', 'singlespaces', 'hyphens'];
     options.fields = options.fields || {};
@@ -97,7 +97,11 @@ _.extend(Form.prototype, {
         return {};
     },
     render: function (req, res, callback) {
-        res.render(this.options.template);
+        if (!this.options.template) {
+            callback(new Error('A template must be provided'));
+        } else {
+            res.render(this.options.template);
+        }
     },
     _getErrors: function (req, res, callback) {
         req.form.errors = this.getErrors(req, res);

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -21,11 +21,11 @@ describe('Form Controller', function () {
         form.should.be.an.instanceOf(EventEmitter);
     });
 
-    it('throws if template is undefined', function () {
+    it('doesn\'t throw if template is undefined', function () {
         var fn = function () {
             return new Form({});
         };
-        fn.should.throw();
+        fn.should.not.throw();
     });
 
     it('throws if options are undefined', function () {
@@ -545,6 +545,13 @@ describe('Form Controller', function () {
         it('renders the provided template', function () {
             form.render(req, res, cb);
             res.render.should.have.been.calledWith('index');
+        });
+
+        it('throws an error if no template provided', function () {
+            var err = new Error('A template must be provided');
+            form.options.template = undefined;
+            form.render(req, res, cb);
+            cb.should.have.been.calledOnce.and.calledWithExactly(err);
         });
 
     });


### PR DESCRIPTION
sometimes we may want to take advantage of controller functionality but not necessarily provide a template to render

* removed error for missing template
* replaced with debug statement advising template is missing
* callback error if render is called without template