### PR TITLE
Allow a field to represent an array of values

### DIFF
--- a/lib/formatting/index.js
+++ b/lib/formatting/index.js
@@ -17,11 +17,21 @@ function format(f, value) {
 
 function formatter(fields, _default) {
     return function (key, value) {
+        if (!Array.isArray(value)) {
+            value = [value];
+        }
         if (_default && !(fields[key] && fields[key]['ignore-defaults'])) {
-            value = format(_default, value);
+            value = value.map(function (item) {
+                return format(_default, item);
+            });
         }
         if (fields[key] && fields[key].formatter) {
-            value = format(fields[key].formatter, value);
+            value = value.map(function (item) {
+                return format(fields[key].formatter, item);
+            });
+        }
+        if (value.length === 1) {
+            value = value[0];
         }
         return value;
     };

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -72,7 +72,12 @@ function validator(fields) {
                     value: true
                 };
             }
-            if (!dependent || (dependent && !fields[dependent.field]) || (dependent && values[dependent.field] === dependent.value)) {
+            if (!dependent
+                || (dependent && !fields[dependent.field])
+                || (dependent && (Array.isArray(values[dependent.field])
+                    ? values[dependent.field].indexOf(dependent.value) > -1
+                    : values[dependent.field] === dependent.value))
+            ) {
                 return true;
             } else {
                 return false;

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -1,4 +1,5 @@
-var moment = require('moment');
+var moment = require('moment'),
+    _ = require('underscore');
 
 // validator methods should return false (or falsy value) for *invalid* input
 // and true (or truthy value) for *valid* input.
@@ -46,7 +47,12 @@ module.exports = Validators = {
 
     equal: function equal(value) {
         var values = [].slice.call(arguments, 1);
-        return values.length && (value === '' || values.indexOf(value) > -1);
+        if (!Array.isArray(value)) {
+            value = [value];
+        }
+        return values.length && _.every(value, function (item) {
+            return item === '' || values.indexOf(item) > -1;
+        });
     },
 
     phonenumber: function phonenumber(value) {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -324,6 +324,18 @@ describe('Form Controller', function () {
             fn.should.not.throw();
         });
 
+        it('applies formtter to array of values', function () {
+            var form = new Form({
+                template: 'index',
+                fields: {
+                    field: { formatter: 'uppercase' }
+                }
+            });
+            req.body.field = ['value', 'another value'];
+            form.post(req, res, cb);
+            req.form.values.field.should.be.eql(['VALUE', 'ANOTHER VALUE']);
+        });
+
         it('writes field values to req.form.values', function () {
             form.post(req, res, cb);
             req.form.values.should.have.keys([

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -1091,7 +1091,7 @@ describe('Form Controller', function () {
                 cb.should.have.been.calledWith();
             });
 
-            describe('Fields that are an array of values', function () {
+            describe('fields that are an array of values', function () {
                 beforeEach(function () {
                     form = new Form({
                         template: 'index',

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -1091,7 +1091,7 @@ describe('Form Controller', function () {
                 cb.should.have.been.calledWith();
             });
 
-            describe('If a field represents an array of values', function () {
+            describe('Fields that are an array of values', function () {
                 beforeEach(function () {
                     form = new Form({
                         template: 'index',

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -324,7 +324,7 @@ describe('Form Controller', function () {
             fn.should.not.throw();
         });
 
-        it('applies formtter to array of values', function () {
+        it('applies formatter to array of values', function () {
             var form = new Form({
                 template: 'index',
                 fields: {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -1091,6 +1091,54 @@ describe('Form Controller', function () {
                 cb.should.have.been.calledWith();
             });
 
+            describe('If a field represents an array of values', function () {
+                beforeEach(function () {
+                    form = new Form({
+                        template: 'index',
+                        fields: {
+                            'field': {},
+                            'field-2': {
+                                validate: [
+                                    'required'
+                                ],
+                                dependent: {
+                                    field: 'field',
+                                    value: 2
+                                }
+                            }
+                        }
+                    });
+                });
+
+                it('should be validated if the dependency exists and is an array containing the value', function () {
+                    req = request({
+                        form: {
+                            values: {
+                                'field': [1, 2, 3],
+                                'field-2': ''
+                            }
+                        }
+                    });
+                    form._validate(req, res, cb);
+                    cb.should.have.been.calledWith({
+                        'field-2': new form.Error('field-2', { type: 'required' })
+                    });
+                });
+
+                it('shouldn\'t be validated if the dependency exists and is an array which doesn\'t contain the value', function () {
+                    req = request({
+                        form: {
+                            values: {
+                                'field': [1, 3, 4],
+                                'field-2': ''
+                            }
+                        }
+                    });
+                    form._validate(req, res, cb);
+                    cb.should.have.been.calledWith();
+                });
+            });
+
         });
 
     });

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -193,7 +193,8 @@ describe('Validators', function () {
                 [true, 'true'],
                 [0, '0'],
                 ['a', 'b', 'c', 'd'],
-                ['a']
+                ['a'],
+                [['a', 'b', 'c'], 'a', 'b']
             ];
             _.each(inputs, function (i) {
                 it(testName(i), function () {
@@ -208,7 +209,8 @@ describe('Validators', function () {
                 ['John Smith', 'John Smith'],
                 [10, 10],
                 [true, true],
-                ['a', 'b', 'c', 'a']
+                ['a', 'b', 'c', 'a'],
+                [['a', 'b'], 'a', 'b']
             ];
             _.each(inputs, function (i) {
                 it(testName(i), function () {


### PR DESCRIPTION
This PR allows a field to represent an array of values. Formatters are applied to each value, the equal validator now checks each value is present in the options array

* convert value to array and apply formatters to each item
* updated the 'equal' validator to check each value if array
* added tests