### PR TITLE
Enhancement/allow array of values

### DIFF
--- a/lib/formatting/index.js
+++ b/lib/formatting/index.js
@@ -17,11 +17,21 @@ function format(f, value) {
 
 function formatter(fields, _default) {
     return function (key, value) {
+        if (!Array.isArray(value)) {
+            value = [value];
+        }
         if (_default && !(fields[key] && fields[key]['ignore-defaults'])) {
-            value = format(_default, value);
+            value = value.map(function (item) {
+                return format(_default, item);
+            });
         }
         if (fields[key] && fields[key].formatter) {
-            value = format(fields[key].formatter, value);
+            value = value.map(function (item) {
+                return format(fields[key].formatter, item);
+            });
+        }
+        if (value.length === 1) {
+            value = value[0];
         }
         return value;
     };

--- a/lib/validation/validators.js
+++ b/lib/validation/validators.js
@@ -1,4 +1,5 @@
-var moment = require('moment');
+var moment = require('moment'),
+    _ = require('underscore');
 
 // validator methods should return false (or falsy value) for *invalid* input
 // and true (or truthy value) for *valid* input.
@@ -46,7 +47,12 @@ module.exports = Validators = {
 
     equal: function equal(value) {
         var values = [].slice.call(arguments, 1);
-        return values.length && (value === '' || values.indexOf(value) > -1);
+        if (!Array.isArray(value)) {
+            value = [value];
+        }
+        return values.length && _.every(value, function (item) {
+            return item === '' || values.indexOf(item) > -1;
+        });
     },
 
     phonenumber: function phonenumber(value) {

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -324,6 +324,18 @@ describe('Form Controller', function () {
             fn.should.not.throw();
         });
 
+        it('applies formtter to array of values', function () {
+            var form = new Form({
+                template: 'index',
+                fields: {
+                    field: { formatter: 'uppercase' }
+                }
+            });
+            req.body.field = ['value', 'another value'];
+            form.post(req, res, cb);
+            req.form.values.field.should.be.eql(['VALUE', 'ANOTHER VALUE']);
+        });
+
         it('writes field values to req.form.values', function () {
             form.post(req, res, cb);
             req.form.values.should.have.keys([

--- a/test/spec/spec.form.js
+++ b/test/spec/spec.form.js
@@ -324,7 +324,7 @@ describe('Form Controller', function () {
             fn.should.not.throw();
         });
 
-        it('applies formtter to array of values', function () {
+        it('applies formatter to array of values', function () {
             var form = new Form({
                 template: 'index',
                 fields: {

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -193,7 +193,8 @@ describe('Validators', function () {
                 [true, 'true'],
                 [0, '0'],
                 ['a', 'b', 'c', 'd'],
-                ['a']
+                ['a'],
+                [['a', 'b', 'c'], 'a', 'b']
             ];
             _.each(inputs, function (i) {
                 it(testName(i), function () {
@@ -208,7 +209,8 @@ describe('Validators', function () {
                 ['John Smith', 'John Smith'],
                 [10, 10],
                 [true, true],
-                ['a', 'b', 'c', 'a']
+                ['a', 'b', 'c', 'a'],
+                [['a', 'b'], 'a', 'b']
             ];
             _.each(inputs, function (i) {
                 it(testName(i), function () {


### PR DESCRIPTION
Patching to so-master

Allow a field to represent an array of values. This PR simply applies formatters to each values and avoids the error thrown by the equals validator.