### PR TITLE
Feature - expose form values to custom validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ By default the application of a validator is optional on empty strings. If you n
 
 #### Custom Validators
 
-Custom validator functions can be passed in field config. These must be named functions and the name is used as the error.type for looking up validation error messages.
+Custom validator functions can be passed in field config. These must be named functions and the name is used as the error.type for looking up validation error messages. The first argument passed is the value of the field, the second argument is a map of all fields and values present on the page.
 
 fields.js
 ```js
 {
     'field-1': {
-        validate: ['required', function isTrue(val) {
-            return val === true;
+        validate: ['required', function isTrue(val, values) {
+            return val !== values['field-2'];
         }]
-    }
+    },
+    'field-2': {}
 }
 ```
 
@@ -153,5 +154,3 @@ let error = new ErrorClass(this.missingDoB, {
     title: 'Something went wrong',
     message: 'Please supply a valid date of birth'});
 ```
-
-

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -3,7 +3,7 @@ var _ = require('underscore'),
 
 var validators = require('./validators');
 
-function applyValidator(validator, value, key) {
+function applyValidator(validator, value, key, values) {
 
     function validate() {
         debug('Applying %s validator with value "%s"', validator.type, value);
@@ -19,7 +19,7 @@ function applyValidator(validator, value, key) {
 
     function customValidate() {
         debug('Applying custom %s validator with value %s', validator.name, value);
-        if (!validator(value)) {
+        if (!validator(value, values)) {
             return _.extend({ key: key }, { type: validator.name });
         }
     }
@@ -88,7 +88,7 @@ function validator(fields) {
             if (shouldValidate()) {
                 debug('Applying validation on field %s with %s', key, value);
                 return _.reduce(fields[key].validate, function (err, validator) {
-                    return err || applyValidator(validator, value, key);
+                    return err || applyValidator(validator, value, key, values);
                 }, null);
             } else {
                 values[key] = emptyValue;

--- a/test/spec/spec.validators.js
+++ b/test/spec/spec.validators.js
@@ -611,6 +611,11 @@ describe('Validators', function () {
                     validate: [function checkVal(val) {
                         return val === true;
                     }]
+                },
+                'field-5': {
+                    validate: [function checkAgainstOtherValues(value, values) {
+                        return value === values['another-field'];
+                    }]
                 }
             };
             validator = validationHelper(fields);
@@ -637,6 +642,13 @@ describe('Validators', function () {
 
         it('validates using the passed values', function () {
             expect(validator('field-4', true)).to.be.undefined;
+        });
+
+        it('passes the form values to the validator', function () {
+            var values = {
+                'another-field': true
+            };
+            expect(validator('field-5', true, values)).to.be.undefined;
         });
     });
 


### PR DESCRIPTION
This is useful in a few cases, one of which is where there are 2 nationality fields and we need to check they don't contain the same value. Currently this can only be achieved by using a custom controller.
- expose values to custom validator function as second argument
- added test
- updated readme
