### PR TITLE
Remove error.title and Error.prototype.getTitle

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -13,20 +13,10 @@ function FormError(key, options, req, res) {
             return options.message || this.getMessage(key, options, req, res);
         }
     });
-    Object.defineProperty(this, 'title', {
-        enumerable: true,
-        get: function () {
-            return options.title || this.getTitle(key, options, req, res);
-        }
-    });
 }
 
 FormError.prototype.getMessage = function (/*key, options, req, res*/) {
     return 'Error';
-};
-
-FormError.prototype.getTitle = function (/*key, options, req, res*/) {
-    return 'Oops, something went wrong';
 };
 
 module.exports = FormError;

--- a/test/spec/spec.error.js
+++ b/test/spec/spec.error.js
@@ -36,14 +36,4 @@ describe('Error', function () {
         err.message.should.equal('My message');
     });
 
-    it('allows a custom title', function () {
-        var err = new ErrorClass('field', { title: 'My error title' });
-        err.title.should.equal('My error title');
-    });
-
-    it('has a default title', function () {
-        var err = new ErrorClass('field', {});
-        err.title.should.exist;
-    });
-
 });


### PR DESCRIPTION
Error properties should generally give details about the nature of the error. Title was added for use in views, this should have been added in a different way.