### PR TITLE
Add "configure" method to request pipeline for dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module.exports = MyForm;
 The Form class allows for a number of insertion points for extended functionality:
 
 * `configure`   Allows for dynamic overwriting of particular points of form configuration based on user session
+* `middlewareMixins`   Allows additional middleware to be added after the configure stage
 * `process`     Allows for custom formatting and processing of input prior to validation
 * `validate`    Allows for custom input validation
 * `getValues`   To define what values the fields are populated with on GET
@@ -148,6 +149,23 @@ For example, for a dynamic address selection component:
 ```js
 MyForm.prototype.configure = function configure(req, res, next) {
     req.form.options.fields['address-select'].options = req.sessionModel.get('addresses');
+    next();
+}
+```
+
+### Middleware mixins
+
+If you want to add middleware that uses dynamic field options then you can use the `middlewareMixins` method. This is called after `configure` so after the dynamic field options are set.
+
+For example, for setting the base url to res locals:
+
+```js
+MyForm.prototype.middlewareMixins = function middlewareMixins(req, res, next) {
+    this.use(this.setBaseUrlLocal).bind(this);
+}
+
+MyForm.prototype.setBaseUrlLocal = function setBaseUrlLocal(req, res, next) {
+    res.locals.baseUrl = req.baseUrl;
     next();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module.exports = MyForm;
 
 The Form class allows for a number of insertion points for extended functionality:
 
+* `configure`   Allows for dynamic overwriting of particular points of form configuration based on user session
 * `process`     Allows for custom formatting and processing of input prior to validation
 * `validate`    Allows for custom input validation
 * `getValues`   To define what values the fields are populated with on GET
@@ -135,5 +136,18 @@ In this example, if the last condition resolves to true - even if the others als
             return typeof req.form.values['email'] === 'undefined';
         }
     }]
+}
+```
+
+### Dynamic field options
+
+If the options for a particular field are dependent on aspects of the user session, then these can be extended on a per-session basis using the `configure` method.
+
+For example, for a dynamic address selection component:
+
+```js
+MyForm.prototype.configure = function configure(req, res, next) {
+    req.form.options.fields['address-select'].options = req.sessionModel.get('addresses');
+    next();
 }
 ```

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,7 +1,8 @@
 /*eslint no-unused-vars: [2, {"vars": "all", "args": "none"}]*/
 var util = require('util'),
     express = require('express'),
-    EventEmitter = require('events').EventEmitter;
+    EventEmitter = require('events').EventEmitter,
+    clone = require('lodash.clonedeep');
 
 var _ = require('underscore'),
     debug = require('debug')('hmpo:form'),
@@ -21,9 +22,6 @@ var Form = function Form(options) {
     this.options = options;
     this.Error = ErrorClass;
 
-    this.formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
-    this.validator = dataValidator(this.options.fields);
-
     this.router = express.Router({ mergeParams: true });
 };
 
@@ -31,6 +29,9 @@ util.inherits(Form, EventEmitter);
 
 _.extend(Form.prototype, {
     requestHandler: function () {
+        this._configure();
+        this.middlewareMixins();
+
         var methods = ['get', 'post', 'put', 'delete'];
         _.each(methods, function (method) {
             if (typeof this[method] === 'function') {
@@ -50,26 +51,22 @@ _.extend(Form.prototype, {
         this.router.use.apply(this.router, arguments);
     },
     get: function (req, res, callback) {
-        req.form = req.form || {};
         var router = express.Router({ mergeParams: true });
         router.use([
             this._getErrors.bind(this),
             this._getValues.bind(this),
             this._locals.bind(this),
+            this._checkStatus.bind(this),
             this.render.bind(this)
         ]);
         router.use(function (err, req, res, next) {
             callback(err);
         });
-        if (_.isEmpty(this.options.fields) && this.options.next) {
-            this.emit('complete', req, res);
-        }
         router.handle(req, res, callback);
     },
     post: function (req, res, callback) {
         this.setErrors(null, req, res);
 
-        req.form = req.form || {};
         var router = express.Router({ mergeParams: true });
         router.use([
             this._process.bind(this),
@@ -82,27 +79,17 @@ _.extend(Form.prototype, {
         });
         router.handle(req, res, callback);
     },
-    _locals: function (req, res, callback) {
-        _.extend(res.locals, {
-            errors: req.form.errors,
-            errorlist: _.map(req.form.errors, _.identity),
-            values: req.form.values,
-            options: this.options,
-            action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
-        });
-        _.extend(res.locals, this.locals(req, res));
+    _configure: function () {
+        this.use(function (req, res, callback) {
+            req.form = req.form || {};
+            req.form.options = clone(this.options);
+            this.configure(req, res, callback);
+        }.bind(this));
+    },
+    configure: function (req, res, callback) {
         callback();
     },
-    locals: function (/*req, res*/) {
-        return {};
-    },
-    render: function (req, res, callback) {
-        if (!this.options.template) {
-            callback(new Error('A template must be provided'));
-        } else {
-            res.render(this.options.template);
-        }
-    },
+    middlewareMixins: function () {},
     _getErrors: function (req, res, callback) {
         req.form.errors = this.getErrors(req, res);
         callback();
@@ -111,14 +98,64 @@ _.extend(Form.prototype, {
     getErrors: function (/*req, res*/) {
         return {};
     },
+    _getValues: function (req, res, callback) {
+        this.getValues(req, res, function (err, values) {
+            req.form.values = values || {};
+            callback(err);
+        });
+    },
+    getValues: function (req, res, callback) {
+        callback();
+    },
+    _locals: function (req, res, callback) {
+        _.extend(res.locals, {
+            errors: req.form.errors,
+            errorlist: _.map(req.form.errors, _.identity),
+            values: req.form.values,
+            options: req.form.options,
+            action: req.baseUrl !== '/' ? req.baseUrl + req.path : req.path
+        });
+        _.extend(res.locals, this.locals(req, res));
+        callback();
+    },
+    locals: function (/*req, res*/) {
+        return {};
+    },
+    _checkStatus: function (req, res, callback) {
+        if (_.isEmpty(req.form.options.fields) && req.form.options.next) {
+            this.emit('complete', req, res);
+        }
+        callback();
+    },
+    render: function (req, res, callback) {
+        if (!req.form.options.template) {
+            callback(new Error('A template must be provided'));
+        } else {
+            res.render(req.form.options.template);
+        }
+    },
     setErrors: function (/*err, req, res*/) {},
+    _process: function (req, res, callback) {
+        req.form.values = req.form.values || {};
+        var formatter = dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        _.each(req.form.options.fields, function (value, key) {
+            req.form.values[key] = formatter(key, req.body[key] || '');
+        });
+        this.process(req, res, callback);
+    },
+    process: function (req, res, callback) {
+        callback();
+    },
     _validate: function (req, res, callback) {
         debug('Validating...');
 
         var errors = {};
 
+        var formatter = dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        var validator = dataValidator(req.form.options.fields);
+
         _.each(req.form.values, function (value, key) {
-            var error = this.validateField(key, req);
+            var error = this.validateField(key, req, validator, formatter);
             if (error) {
                 if (error.group) {
                     errors[error.group] = new this.Error(error.group, error, req, res);
@@ -137,32 +174,28 @@ _.extend(Form.prototype, {
     validate: function (req, res, callback) {
         callback();
     },
-    validateField: function (key, req) {
-        var emptyValue = this.formatter(key, '');
-        return this.validator(key, req.form.values[key], req.form.values, emptyValue);
-    },
-    _process: function (req, res, callback) {
-        req.form = { values: {} };
-        var formatter = dataFormatter(this.options.fields, this.options.defaultFormatters);
-        _.each(this.options.fields, function (value, key) {
-            req.form.values[key] = formatter(key, req.body[key] || '');
-        });
-        this.process(req, res, callback);
-    },
-    process: function (req, res, callback) {
-        callback();
-    },
-    _getValues: function (req, res, callback) {
-        this.getValues(req, res, function (err, values) {
-            req.form.values = values || {};
-            callback(err);
-        });
-    },
-    getValues: function (req, res, callback) {
-        callback();
+    validateField: function (key, req, validator, formatter) {
+        formatter = formatter || dataFormatter(req.form.options.fields, req.form.options.defaultFormatters);
+        validator = validator || dataValidator(req.form.options.fields);
+        var emptyValue = formatter(key, '');
+        return validator(key, req.form.values[key], req.form.values, emptyValue);
     },
     saveValues: function (req, res, callback) {
         callback();
+    },
+    successHandler: function (req, res) {
+        this.emit('complete', req, res);
+        res.redirect(this.getNextStep(req, res));
+    },
+    getNextStep: function (req, res) {
+        var next = req.form.options.next || req.path;
+        if (req.form.options.forks && Array.isArray(req.form.options.forks)) {
+            next = this._getForkTarget(req, res);
+        }
+        if (req.baseUrl !== '/') {
+            next = req.baseUrl + next;
+        }
+        return next;
     },
     _getForkTarget: function (req, res) {
         function evalCondition(condition) {
@@ -172,24 +205,23 @@ _.extend(Form.prototype, {
         }
 
         // If a fork condition is met, its target supercedes the next property
-        return this.options.forks.reduce(function (result, value) {
+        return req.form.options.forks.reduce(function (result, value) {
             return evalCondition(value.condition) ?
                 value.target :
                 result;
-        }, this.options.next);
+        }, req.form.options.next);
     },
     getForkTarget: function (req, res) {
         return this._getForkTarget(req, res);
     },
-    getNextStep: function (req, res) {
-        var next = this.options.next || req.path;
-        if (this.options.forks && Array.isArray(this.options.forks)) {
-            next = this._getForkTarget(req, res);
+    errorHandler: function (err, req, res, callback) {
+        if (this.isValidationError(err)) {
+            this.setErrors(err, req, res);
+            res.redirect(this.getErrorStep(err, req));
+        } else {
+            // if the error is not a validation error then throw and let the error handler pick it up
+            return callback(err);
         }
-        if (req.baseUrl !== '/') {
-            next = req.baseUrl + next;
-        }
-        return next;
     },
     getErrorStep: function (err, req) {
         var redirect = req.path;
@@ -209,19 +241,6 @@ _.extend(Form.prototype, {
     },
     isValidationError: function (err) {
         return !_.isEmpty(err) && _.all(err, function (e) { return e instanceof this.Error; }, this);
-    },
-    errorHandler: function (err, req, res, callback) {
-        if (this.isValidationError(err)) {
-            this.setErrors(err, req, res);
-            res.redirect(this.getErrorStep(err, req));
-        } else {
-            // if the error is not a validation error then throw and let the error handler pick it up
-            return callback(err);
-        }
-    },
-    successHandler: function (req, res) {
-        this.emit('complete', req, res);
-        res.redirect(this.getNextStep(req, res));
     }
 });
 

--- a/lib/validation/index.js
+++ b/lib/validation/index.js
@@ -61,6 +61,7 @@ function validator(fields) {
     });
 
     return function (key, value, values, emptyValue) {
+        debug('Validating field: "' + key + '" with value: "' + value + '"');
         emptyValue = emptyValue === undefined ? '' : emptyValue;
 
         function shouldValidate() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "debug": "^2.1.1",
     "express": "^4.12.3",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.9.0",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
This feature has been added to the HOF version of the form controller https://github.com/UKHomeOfficeForms/hof-form-controller/pull/4. This PR is lifting that update across (with a few extra tests for the checkEmpty method): https://github.com/UKHomeOffice/passports-form-controller/commit/23c22a8ee74e07c01a0f995b17da98d1f73e64be.

Also, form.js is a long file and I found it helpful to shuffle around the order of methods to better match up to the request pipeline sequences:  https://github.com/UKHomeOffice/passports-form-controller/commit/4c018afaf5eb3cc8f53a032f68e2063e2f8e7409.